### PR TITLE
Correct Typos in Method Names

### DIFF
--- a/service/src/main/java/datawave/microservice/accumulo/config/AccumuloConfiguration.java
+++ b/service/src/main/java/datawave/microservice/accumulo/config/AccumuloConfiguration.java
@@ -23,7 +23,7 @@ public class AccumuloConfiguration {
     @Lazy
     @Qualifier("warehouse")
     @ConditionalOnMissingBean
-    public AccumuloProperties warehouseAccumuloProperies(WarehouseClusterProperties warehouseProperties) {
+    public AccumuloProperties warehouseAccumuloProperties(WarehouseClusterProperties warehouseProperties) {
         return warehouseProperties.getAccumulo();
     }
     
@@ -31,7 +31,7 @@ public class AccumuloConfiguration {
     @Lazy
     @Qualifier("metrics")
     @ConditionalOnMissingBean
-    public AccumuloProperties metricsAccumuloProperies(MetricsClusterProperties metricsProperties) {
+    public AccumuloProperties metricsAccumuloProperties(MetricsClusterProperties metricsProperties) {
         return metricsProperties.getAccumulo();
     }
     


### PR DESCRIPTION
Corrects method names that have incorrect spelling.

This PR is related to [dw-query-metric-service PR #21](https://github.com/NationalSecurityAgency/datawave-query-metric-service/pull/21)